### PR TITLE
Fix import paths (and gofmt).

### DIFF
--- a/src/gpg2hs/main.go
+++ b/src/gpg2hs/main.go
@@ -26,7 +26,6 @@ package main
 
 import (
 	"bufio"
-	"code.google.com/p/go.crypto/openpgp"
 	"crypto/rsa"
 	"crypto/sha1"
 	"crypto/x509"
@@ -40,6 +39,8 @@ import (
 	"os/user"
 	"strconv"
 	"strings"
+
+	"golang.org/x/crypto/openpgp"
 )
 
 ///////////////////////////////////////////////////////////////////////

--- a/src/hs2gpg/main.go
+++ b/src/hs2gpg/main.go
@@ -24,9 +24,6 @@ package main
 
 import (
 	"bufio"
-	"code.google.com/p/go.crypto/openpgp"
-	"code.google.com/p/go.crypto/openpgp/armor"
-	"code.google.com/p/go.crypto/openpgp/packet"
 	"crypto"
 	"crypto/rsa"
 	"crypto/x509"
@@ -37,14 +34,18 @@ import (
 	"log"
 	"os"
 	"time"
+
+	"golang.org/x/crypto/openpgp"
+	"golang.org/x/crypto/openpgp/armor"
+	"golang.org/x/crypto/openpgp/packet"
 )
 
 ///////////////////////////////////////////////////////////////////////
 // package-global variables
 
 var (
-	keyfile   string
-	gpgkey   string
+	keyfile string
+	gpgkey  string
 )
 
 ///////////////////////////////////////////////////////////////////////
@@ -53,7 +54,7 @@ var (
 /*
  * Read RSA-1024 key from file
  * @param fName string - name of file to be read
- * @return *rsa.PrivateKey - key read from file	
+ * @return *rsa.PrivateKey - key read from file
  */
 func readHiddenServiceKey(fName string) *rsa.PrivateKey {
 	fp, err := os.Open(fName)
@@ -97,7 +98,7 @@ func readHiddenServiceKey(fName string) *rsa.PrivateKey {
 /*
  * Read GnuPG entity from file
  * @param fName string - name of file to be read
- * @return *rsa.PrivateKey - key read from file	
+ * @return *rsa.PrivateKey - key read from file
  */
 func readGpgKey(fName string) *openpgp.Entity {
 	fp, err := os.Open(fName)
@@ -135,7 +136,7 @@ func main() {
 
 	// read hiden service key
 	subKey := readHiddenServiceKey(keyfile)
-	
+
 	// read GnuPG entity file
 	ent := readGpgKey(gpgkey)
 	pk := ent.PrivateKey
@@ -159,18 +160,18 @@ func main() {
 	now := time.Now()
 	pubKey := packet.NewRSAPublicKey(now, &subKey.PublicKey)
 	sig := packet.Signature{
-		Hash: crypto.SHA256,
+		Hash:       crypto.SHA256,
 		PubKeyAlgo: pubKey.PubKeyAlgo,
 	}
-	
+
 	if err := sig.SignKey(pubKey, pk, nil); err != nil {
 		log.Fatal("[6]" + err.Error())
 	}
 	sub := openpgp.Subkey{
-		PublicKey: pubKey,
+		PublicKey:  pubKey,
 		PrivateKey: packet.NewRSAPrivateKey(now, subKey),
-		Sig: &sig,
-	} 
+		Sig:        &sig,
+	}
 	// add subkey to entity
 	ent.Subkeys = append(ent.Subkeys, sub)
 


### PR DESCRIPTION
code.google.com is closing down, the go sub-repositories moved last year to golang.org/x.

The other changes are because I was lazy and did the import changes by just removing the old imports and saving, letting `goimports` do it's thing.
